### PR TITLE
Add stock command using yahoo-finance2 library

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "nodemon": "^2.0.19",
     "prettier": "^2.7.1",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "yahoo-finance2": "^2.3.6"
   },
   "dependencies": {
     "@discordjs/opus": "^0.8.0",

--- a/src/commands/stock.command.ts
+++ b/src/commands/stock.command.ts
@@ -1,0 +1,115 @@
+import CommandInterface from '../command.interface';
+import { Service } from 'typedi';
+import {
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    SlashCommandBuilder,
+    SlashCommandSubcommandsOnlyBuilder,
+} from 'discord.js';
+import { SubCommand } from '../sub-command.type';
+import { Subject } from 'rxjs';
+import yahooFinance from 'yahoo-finance2';
+
+function shittyNumFormatter(num: number): string {
+    if (num >= 1000000000000) {
+        return (num / 1000000000000).toFixed(2) + 'T';
+    } else if (num >= 1000000000) {
+        return (num / 1000000000).toFixed(2) + 'B';
+    } else if (num >= 1000000) {
+        return (num / 1000000).toFixed(2) + 'M';
+    } else if (num >= 1000) {
+        return (num / 1000).toFixed(2) + 'K';
+    } else {
+        return num + '';
+    }
+}
+
+@Service()
+export default class StockCommand implements CommandInterface {
+    command = 'stock';
+    subCommands = new Array<SubCommand>();
+    subCommandSubject = new Subject<ChatInputCommandInteraction>();
+
+    async init() {
+        this.subCommands.push({
+            command: 'quote',
+            runCommand: async (interaction) => {
+                const ticker = interaction.options.getString('ticker');
+
+                await interaction.deferReply();
+
+                const quote = await yahooFinance.quote(ticker as string);
+
+                if (!quote) {
+                    await interaction.reply({ content: `Invalid stock ticker specified: ${ticker}`, ephemeral: true });
+                    return;
+                }
+
+                const quoteType = quote['quoteType'];
+                if (quoteType !== 'EQUITY' && quoteType !== 'ETF' && quoteType !== 'INDEX') {
+                    await interaction.reply({
+                        content: `Sorry, stock type "${quoteType}" is not supported at this time.`,
+                        ephemeral: true,
+                    });
+                    return;
+                }
+
+                const name = (!quote['longName'] && quote['shortName']) || quote['longName'];
+                const exchange = quote['fullExchangeName'];
+                const price = (quote['regularMarketPrice'] as number).toFixed(2);
+                const currency = quote['currency'];
+                const change = parseFloat((quote['regularMarketChange'] as number).toFixed(2));
+                const changeIcon = (change > 0 && '▲') || (change < 0 && '▼') || '■';
+                const changeColor = (change > 0 && 'Green') || (change < 0 && 'Red') || 'Grey';
+                const changePct = (quote['regularMarketChangePercent'] as number).toFixed(2);
+                const priceOpen = (quote['regularMarketOpen'] as number).toFixed(2);
+                const marketCap = (!quote['marketCap'] && 'N/A') || shittyNumFormatter(quote['marketCap'] as number);
+                const marketDayLow = (quote['regularMarketDayLow'] as number).toFixed(2);
+                const marketDayHigh = (quote['regularMarketDayHigh'] as number).toFixed(2);
+
+                const embed = new EmbedBuilder()
+                    .setTitle(`Stock Market: ${ticker}`)
+                    .setURL('https://finance.yahoo.com/quote/' + ticker)
+                    .setDescription(`${name}`)
+                    .addFields(
+                        { name: 'Price', value: `${price} ${currency}`, inline: true },
+                        { name: 'Change', value: `${changeIcon} ${change} (${changePct}%)`, inline: true },
+                        { name: '\u200B', value: '\u200B', inline: true },
+                    )
+                    .addFields(
+                        { name: 'Day Open', value: `${priceOpen}`, inline: true },
+                        { name: 'Day Low', value: `${marketDayLow}`, inline: true },
+                        { name: 'Day High', value: `${marketDayHigh}`, inline: true },
+                        { name: 'Market Cap', value: `${marketCap}` },
+                    )
+                    .setTimestamp()
+                    .setFooter({ text: `Price retrieved from ${exchange} via Yahoo Finance.` })
+                    .setColor(changeColor);
+
+                await interaction.editReply({ embeds: [embed] });
+            },
+        });
+        return;
+    }
+
+    async runCommand(interaction: ChatInputCommandInteraction) {
+        return;
+    }
+
+    slashCommandBuilder(): SlashCommandSubcommandsOnlyBuilder | SlashCommandBuilder {
+        return new SlashCommandBuilder()
+            .setName(this.command)
+            .setDescription('View stock information')
+            .addSubcommand((subcommand) =>
+                subcommand
+                    .setName('quote')
+                    .setDescription('retrieve stock information')
+                    .addStringOption((option) =>
+                        option
+                            .setName('ticker')
+                            .setDescription('The ticker code of the desired stock.')
+                            .setRequired(true),
+                    ),
+            );
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import DiceCommand from './commands/dice.command';
 import WolframAlphaCommand from './commands/wolfram-alpha.command';
 import RadioCommand from './commands/radio.command';
 import DiscordMusicService from './services/discord-music.service';
+import StockCommand from './commands/stock.command';
 import { filter } from 'rxjs';
 
 const discordService = Container.get(DiscordService);
@@ -25,6 +26,7 @@ commands.push(Container.get(DisableCommandCommand));
 commands.push(Container.get(DiceCommand));
 commands.push(Container.get(WolframAlphaCommand));
 commands.push(Container.get(RadioCommand));
+commands.push(Container.get(StockCommand));
 
 const services = new Array<ServiceInterface>();
 services.push(Container.get(QuoteService));


### PR DESCRIPTION
This adds a `/stock quote` command for retrieving stock market information using the yahoo-finance2 library.

![image](https://user-images.githubusercontent.com/18068959/185920217-6a6ddcce-b61b-44fa-9fc5-a04b1e19d535.png)

Command syntax: `/stock quote <tickername>`