### PR TITLE
Add about command

### DIFF
--- a/src/commands/about.command.ts
+++ b/src/commands/about.command.ts
@@ -1,0 +1,41 @@
+import {
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    SlashCommandBuilder,
+    SlashCommandSubcommandsOnlyBuilder,
+} from 'discord.js';
+import { Service } from 'typedi';
+import CommandInterface from '../command.interface';
+import { SubCommand } from '../sub-command.type';
+import { Subject } from 'rxjs';
+import { InteractionHandler } from '../interaction-handler.type';
+
+@Service()
+export default class AboutCommand implements CommandInterface {
+    command = 'about';
+    subCommands = new Array<SubCommand>();
+    interactionHandlers = new Array<InteractionHandler>();
+    subCommandSubject = new Subject<ChatInputCommandInteraction>();
+
+    async init(): Promise<void> {
+        return;
+    }
+
+    async runCommand(interaction: ChatInputCommandInteraction): Promise<void> {
+        const embed = new EmbedBuilder()
+            .setTitle(`About Lag-Bot`)
+            .setURL('https://github.com/Zowlyfon/lag-bot')
+            .setDescription('Lag-Bot was lovely made in TypeScript by Zowlyfon and other GNULag users.')
+            .addFields(
+                { name: 'Repository', value: 'https://github.com/Zowlyfon/lag-bot' },
+                { name: 'Licence', value: 'GNU Affero General Public License v3.0' },
+            )
+            .setColor('Green');
+
+        await interaction.reply({ embeds: [embed] });
+    }
+
+    slashCommandBuilder(): SlashCommandSubcommandsOnlyBuilder | SlashCommandBuilder {
+        return new SlashCommandBuilder().setName('about').setDescription('Display information about the bot.');
+    }
+}

--- a/src/commands/about.command.ts
+++ b/src/commands/about.command.ts
@@ -25,7 +25,7 @@ export default class AboutCommand implements CommandInterface {
         const embed = new EmbedBuilder()
             .setTitle(`About Lag-Bot`)
             .setURL('https://github.com/Zowlyfon/lag-bot')
-            .setDescription('Lag-Bot was lovely made in TypeScript by Zowlyfon and other GNULag users.')
+            .setDescription('Lag-Bot was lovingly made in TypeScript by Zowlyfon and other GNULag users.')
             .addFields(
                 { name: 'Repository', value: 'https://github.com/Zowlyfon/lag-bot' },
                 { name: 'Licence', value: 'GNU Affero General Public License v3.0' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import WeatherCommand from './commands/weather.command';
 import WeatherService from './services/weather.service';
 import BibleCommand from './commands/bible.command';
 import BibleService from './services/bible.service';
+import AboutCommand from './commands/about.command';
 
 const discordService = Container.get(DiscordService);
 
@@ -36,6 +37,7 @@ commands.push(Container.get(StockCommand));
 commands.push(Container.get(FetishCommand));
 commands.push(Container.get(WeatherCommand));
 commands.push(Container.get(BibleCommand));
+commands.push(Container.get(AboutCommand));
 
 const services = new Array<ServiceInterface>();
 services.push(Container.get(QuoteService));


### PR DESCRIPTION
Adds an about command that points to this repo.

Usage: `/about`

![image](https://user-images.githubusercontent.com/18068959/186821278-cd13c4d5-8ffc-42dd-b560-ae145132fe63.png)

(I fixed the typo as well. I just can't be bothered adding a new screenshot)
